### PR TITLE
Don't open external links in the Electron context

### DIFF
--- a/react/src/components/dashboard/support/support.js
+++ b/react/src/components/dashboard/support/support.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { translate } from '../../../translate/translate';
-import electron from 'electron';
 
 class Support extends React.Component {
   constructor() {
@@ -8,7 +7,7 @@ class Support extends React.Component {
   }
 
   openExternalWindow(url) {
-    return electron.shell.openExternal(url);
+    return window.require('electron').shell.openExternal(url);
   }
 
   render() {

--- a/react/src/components/dashboard/support/support.js
+++ b/react/src/components/dashboard/support/support.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { translate } from '../../../translate/translate';
+import electron from 'electron';
 
 class Support extends React.Component {
   constructor() {
@@ -7,22 +8,7 @@ class Support extends React.Component {
   }
 
   openExternalWindow(url) {
-    const remote = window.require('electron').remote;
-    const BrowserWindow = remote.BrowserWindow;
-
-    const externalWindow = new BrowserWindow({
-      width: 1280,
-      height: 800,
-      title: `${translate('INDEX.LOADING')}...`,
-      icon: remote.getCurrentWindow().iguanaIcon,
-    });
-
-    externalWindow.loadURL(url);
-    externalWindow.webContents.on('did-finish-load', () => {
-      setTimeout(() => {
-        externalWindow.show();
-      }, 40);
-    });
+    return electron.shell.openExternal(url);
   }
 
   render() {


### PR DESCRIPTION
If external links are opened in the Electron context, any JavaScript running on those sites can access the main Node.js process and will get remote code execution on the users OS.