### PR TITLE
Notifications

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -42,6 +42,7 @@
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.24.1",
     "bluebird": "^3.5.0",
+    "electron-native-notify": "^1.1.5",
     "ethers": "git://github.com/pbca26/ethers.js",
     "express": "^4.14.0",
     "file-loader": "^0.10.0",

--- a/react/src/reducers/toaster.js
+++ b/react/src/reducers/toaster.js
@@ -2,6 +2,7 @@ import {
   ADD_TOASTER_MESSAGE,
   REMOVE_TOASTER_MESSAGE,
 } from '../actions/storeType';
+import config from '../config';
 import notify from 'electron-native-notify';
 
 const arrayToString = (arr) => {
@@ -19,7 +20,7 @@ export const toaster = (state = {
 
   switch (action.type) {
     case ADD_TOASTER_MESSAGE:
-      if(notify.isSupported()) {
+      if(config.notifications && notify.isSupported()) {
 	notify(action.title, action.message.join ? action.message.join('\n') : action.message);
         return state;
       }

--- a/react/src/reducers/toaster.js
+++ b/react/src/reducers/toaster.js
@@ -2,6 +2,7 @@ import {
   ADD_TOASTER_MESSAGE,
   REMOVE_TOASTER_MESSAGE,
 } from '../actions/storeType';
+import notify from 'electron-native-notify';
 
 const arrayToString = (arr) => {
   if (typeof arr === 'object') {
@@ -18,6 +19,11 @@ export const toaster = (state = {
 
   switch (action.type) {
     case ADD_TOASTER_MESSAGE:
+      if(notify.isSupported()) {
+	notify(action.title, action.message.join ? action.message.join('\n') : action.message);
+        return state;
+      }
+
       let _isSameToastTwice = false;
 
       for (let i = 0; i < state.toasts.length; i++) {

--- a/react/webpack.config.js
+++ b/react/webpack.config.js
@@ -160,6 +160,7 @@ if (isProduction) {
 }
 
 module.exports = {
+  target: 'electron-renderer',
   devtool: isProduction ? 'eval' : 'source-map',
   context: jsSourcePath,
   entry: {

--- a/react/webpack.prod.config.js
+++ b/react/webpack.prod.config.js
@@ -160,6 +160,7 @@ if (isProduction) {
 }
 
 module.exports = {
+  target: 'electron-renderer',
   devtool: isProduction ? 'eval' : 'source-map',
   context: jsSourcePath,
   entry: {


### PR DESCRIPTION
adds native notifications support

need this setting pr and turn on setting for it to be work https://github.com/KomodoPlatform/Agama/pull/229

by default just normal toast notification

if notification setting turned on and operating systems has support for the notification we show native notification

even with setting on if os has no notifications support it will be fall back to toast notification

toast notifications

![agama-ubuntu-toast](https://user-images.githubusercontent.com/46623667/54407566-3523e000-46d6-11e9-8433-50bf5061b116.png)

native notification

![agama-ubuntu-native](https://user-images.githubusercontent.com/46623667/54407572-40770b80-46d6-11e9-8eb5-98f13b8f6797.png)

mac native notification

<img width="1680" alt="agama-osx-native" src="https://user-images.githubusercontent.com/46623667/54407582-4836b000-46d6-11e9-9d27-fad992f25ddf.png">

don t have windows machine for tests but sure it will be working

